### PR TITLE
feat: propagate failed http status codes

### DIFF
--- a/cmd/aepcli/main_test.go
+++ b/cmd/aepcli/main_test.go
@@ -22,7 +22,7 @@ func TestAepcli(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := aepcli(tt.args)
+			code, err := aepcli(tt.args)
 
 			if tt.wantErr {
 				if err == nil {
@@ -37,6 +37,10 @@ func TestAepcli(t *testing.T) {
 
 			if err != nil {
 				t.Errorf("aepcli() unexpected error = %v", err)
+			}
+
+			if code != 0 {
+				t.Errorf("aepcli() unexpected exit code = %v, want 0", code)
 			}
 		})
 	}

--- a/internal/service/resource_definition_test.go
+++ b/internal/service/resource_definition_test.go
@@ -55,7 +55,7 @@ func getTestAPI() *api.API {
 		ServerURL: "https://api.example.com",
 		Resources: map[string]*api.Resource{
 			"project": &projectResource,
-			"dataset": &api.Resource{
+			"dataset": {
 				Singular: "dataset",
 				Plural:   "datasets",
 				Parents:  []string{"project"},
@@ -68,13 +68,13 @@ func getTestAPI() *api.API {
 					Delete: &api.DeleteMethod{},
 				},
 			},
-			"user": &api.Resource{
+			"user": {
 				Singular: "user",
 				Plural:   "users",
 				Parents:  []string{},
 				Schema:   &openapi.Schema{},
 			},
-			"comment": &api.Resource{
+			"comment": {
 				Singular: "comment",
 				Plural:   "comments",
 				Parents:  []string{},

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -52,8 +52,8 @@ func TestService_ExecuteCommand_ListResources(t *testing.T) {
 				} else if !strings.Contains(err.Error(), tt.expected) {
 					t.Errorf("ExecuteCommand() error = %v, expected it to contain %v", err, tt.expected)
 				}
-			} else if !strings.Contains(result, tt.expected) {
-				t.Errorf("ExecuteCommand() = %q, expected it to contain %q", result, tt.expected)
+			} else if !strings.Contains(result.Output, tt.expected) {
+				t.Errorf("ExecuteCommand() = %q, expected it to contain %q", result.Output, tt.expected)
 			}
 		})
 	}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -1,0 +1,8 @@
+package service
+
+type Result struct {
+	Output string
+	// StatusCode should be 0 for undefined, or
+	// the HTTP status code of the response.
+	StatusCode int
+}


### PR DESCRIPTION
If a HTTP request fails (e.g. a resource is not found), propagate that as a failed (2) exit code.