### PR TITLE
fix(description): use descriptions from schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,6 @@ require (
 	golang.org/x/text v0.19.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// uncomment for local development.
+// replace github.com/aep-dev/aep-lib-go => ../aep-lib-go

--- a/internal/service/resource_definition.go
+++ b/internal/service/resource_definition.go
@@ -202,6 +202,10 @@ func ExecuteResourceCommand(r *api.Resource, args []string) (*http.Request, stri
 
 func addSchemaFlags(c *cobra.Command, schema openapi.Schema, args map[string]interface{}) error {
 	for name, prop := range schema.Properties {
+		description := prop.Description
+		if description == "" {
+			description = fmt.Sprintf("The %v of the resource", name)
+		}
 		if prop.ReadOnly {
 			continue
 		}
@@ -209,34 +213,34 @@ func addSchemaFlags(c *cobra.Command, schema openapi.Schema, args map[string]int
 		case "string":
 			var value string
 			args[name] = &value
-			c.Flags().StringVar(&value, name, "", fmt.Sprintf("The %v of the resource", name))
+			c.Flags().StringVar(&value, name, "", description)
 		case "integer":
 			var value int
 			args[name] = &value
-			c.Flags().IntVar(&value, name, 0, fmt.Sprintf("The %v of the resource", name))
+			c.Flags().IntVar(&value, name, 0, description)
 		case "number":
 			var value float64
 			args[name] = &value
-			c.Flags().Float64Var(&value, name, 0, fmt.Sprintf("The %v of the resource", name))
+			c.Flags().Float64Var(&value, name, 0, description)
 		case "boolean":
 			var value bool
 			args[name] = &value
-			c.Flags().BoolVar(&value, name, false, fmt.Sprintf("The %v of the resource", name))
+			c.Flags().BoolVar(&value, name, false, description)
 		case "array":
 			if prop.Items == nil {
 				return fmt.Errorf("items is required for array type, not found for field %v", name)
 			}
 			var value []interface{}
 			args[name] = &value
-			c.Flags().Var(&ArrayFlag{&value, prop.Items.Type}, name, fmt.Sprintf("The %v of the resource", name))
+			c.Flags().Var(&ArrayFlag{&value, prop.Items.Type}, name, description)
 		case "object":
 			var parsedValue map[string]interface{}
 			args[name] = &parsedValue
-			c.Flags().Var(&JSONFlag{&parsedValue}, name, fmt.Sprintf("The %v of the resource", name))
+			c.Flags().Var(&JSONFlag{&parsedValue}, name, description)
 		default:
 			var parsedValue map[string]interface{}
 			args[name] = &parsedValue
-			c.Flags().Var(&JSONFlag{&parsedValue}, name, fmt.Sprintf("The %v of the resource", name))
+			c.Flags().Var(&JSONFlag{&parsedValue}, name, description)
 		}
 	}
 	for _, f := range schema.Required {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -22,12 +22,12 @@ func TestService_ExecuteCommand_ListResources(t *testing.T) {
 		{
 			name:     "no arguments",
 			args:     []string{},
-			expected: "Available resources:\n  - comment\n  - dataset\n  - project\n  - user\n",
+			expected: "Available resources:\n  - book\n  - comment\n  - dataset\n  - project\n  - shelf\n  - user\n",
 		},
 		{
 			name:     "help flag",
 			args:     []string{"--help"},
-			expected: "Available resources:\n  - comment\n  - dataset\n  - project\n  - user\n",
+			expected: "Available resources:\n  - book\n  - comment\n  - dataset\n  - project\n  - shelf\n  - user\n",
 		},
 		{
 			name:          "unknown resource",


### PR DESCRIPTION
Using descriptions from the oas schema if available, which are generally more descriptive.